### PR TITLE
Update to the latest scotty version without ScottyError and addition of MonadUnliftIO.

### DIFF
--- a/scotty-resource.cabal
+++ b/scotty-resource.cabal
@@ -18,6 +18,14 @@ build-type:          Simple
 -- extra-source-files:  
 cabal-version:       >=1.10
 
+tested-with:         GHC == 8.10.7
+                   , GHC == 9.0.2
+                   , GHC == 9.2.8
+                   , GHC == 9.4.6
+                   , GHC == 9.6.4
+                   , GHC == 9.8.2
+                   , GHC == 9.10.3
+
 library
   exposed-modules:     
     Web.Scotty.Resource.Trans
@@ -25,12 +33,13 @@ library
   other-extensions:    
     OverloadedStrings
   build-depends:
-    base         >= 4.11     && < 4.12,
-    containers   >= 0.1.0.0  && < 0.6,
+    base         >= 4.11     && < 4.21,
+    containers   >= 0.1.0.0  && < 0.8,
     http-types   >= 0.8.2    && < 0.13,
-    scotty       >= 0.10     && < 0.12,
-    text         >= 0.11.3.1 && < 1.3,
-    transformers >= 0.3.0.0  && < 0.6,
+    scotty       >= 0.22     && < 0.23,
+    text         >= 0.11.3.1 && < 2.2,
+    unliftio     >= 0.2      && < 0.3,
+    transformers >= 0.3.0.0  && < 0.7,
     wai          >= 3.0.0    && < 3.3
   hs-source-dirs: src
   default-language: Haskell2010

--- a/src/Web/Scotty/Resource/Trans.hs
+++ b/src/Web/Scotty/Resource/Trans.hs
@@ -128,15 +128,16 @@ import Data.Text.Lazy (fromStrict)
 import Network.HTTP.Types (Method, methodNotAllowed405)
 import Network.Wai (requestMethod)
 import Web.Scotty.Trans (ActionT, RoutePattern, ScottyT, matchAny,
-  request, ScottyError, setHeader, status)
+  request, setHeader, status)
+import UnliftIO (MonadUnliftIO)
 
 {- |
   Add a resource whose uri matches the route pattern.
 -}
-resource :: (MonadIO m, ScottyError e)
+resource :: (MonadIO m, MonadUnliftIO m)
   => RoutePattern
-  -> WebResource e m ()
-  -> ScottyT e m ()
+  -> WebResource m ()
+  -> ScottyT m ()
 resource uri (W methods ()) = matchAny uri $
     getMethod `liftM` request >>= fromMaybe notAllowed
   where
@@ -163,18 +164,18 @@ resource uri (W methods ()) = matchAny uri $
   An opaque representation of an http resource. Use `get`, `post`, etc. to
   create one of these. Use the `Monad` or `Semigroup` instances to compose them.
 -}
-data WebResource e m a = W [(Method, ActionT e m ())] a
-instance Functor (WebResource e m) where
+data WebResource m a = W [(Method, ActionT m ())] a
+instance Functor (WebResource m) where
   fmap = liftM
-instance Applicative (WebResource e m) where
-  pure = return
+instance Applicative (WebResource m) where
+  pure = W []
   (<*>) = ap
-instance Monad (WebResource e m) where
-  return = W []
+instance Monad (WebResource m) where
+  return = pure
   W methods a >>= f =
     let W newMethods b = f a
     in W (methods <> newMethods) b
-instance Semigroup (WebResource e m a) where
+instance Semigroup (WebResource m a) where
   W a _ <> W b c = W (a <> b) c
 
 
@@ -182,7 +183,7 @@ instance Semigroup (WebResource e m a) where
   Create a `WebResource` that handles OPTIONS requests using the given
   scotty action.
 -}
-options :: ActionT e m () -> WebResource e m ()
+options :: ActionT m () -> WebResource m ()
 options action = W [("OPTIONS", action)] ()
 
 
@@ -190,7 +191,7 @@ options action = W [("OPTIONS", action)] ()
   Create a `WebResource` that handles GET requests using the given
   scotty action.
 -}
-get :: ActionT e m () -> WebResource e m ()
+get :: ActionT m () -> WebResource m ()
 get action = W [("GET", action)] ()
 
 
@@ -198,7 +199,7 @@ get action = W [("GET", action)] ()
   Create a `WebResource` that handles HEAD requests using the given
   scotty action.
 -}
-head :: ActionT e m () -> WebResource e m ()
+head :: ActionT m () -> WebResource m ()
 head action = W [("HEAD", action)] ()
 
 
@@ -206,7 +207,7 @@ head action = W [("HEAD", action)] ()
   Create a `WebResource` that handles POST requests using the given
   scotty action.
 -}
-post :: ActionT e m () -> WebResource e m ()
+post :: ActionT m () -> WebResource m ()
 post action = W [("POST", action)] ()
 
 
@@ -214,7 +215,7 @@ post action = W [("POST", action)] ()
   Create a `WebResource` that handles PUT requests using the given
   scotty action.
 -}
-put :: ActionT e m () -> WebResource e m ()
+put :: ActionT m () -> WebResource m ()
 put action = W [("PUT", action)] ()
 
 
@@ -222,7 +223,7 @@ put action = W [("PUT", action)] ()
   Create a `WebResource` that handles DELETE requests using the given
   scotty action.
 -}
-delete :: ActionT e m () -> WebResource e m ()
+delete :: ActionT m () -> WebResource m ()
 delete action = W [("DELETE", action)] ()
 
 
@@ -230,7 +231,7 @@ delete action = W [("DELETE", action)] ()
   Create a `WebResource` that handles PATCH requests using the given
   scotty action.
 -}
-patch :: ActionT e m () -> WebResource e m ()
+patch :: ActionT m () -> WebResource m ()
 patch action = W [("PATCH", action)] ()
 
 
@@ -238,7 +239,7 @@ patch action = W [("PATCH", action)] ()
   Create a `WebResource` that handles the specific method using the given
   scotty action.
 -}
-method :: Method -> ActionT e m () -> WebResource e m ()
+method :: Method -> ActionT m () -> WebResource m ()
 method m action = W [(m, action)] ()
 
 


### PR DESCRIPTION
This will cause a break change.

Also added the same `tested-with` as scotty, since it doesn't seem that scotty-resource uses anything that could fail.  So, I hope it should work on the same GHC versions.